### PR TITLE
fixes artifact id

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is JVM (written in Kotlin) SDK for enabling Maxim observability. [Maxim](ht
 
 1. Gradle/Groovy
 ```groovy
-implementation("dev.getmaxim.sdk:maxim-java:0.1.2")
+implementation("dev.getmaxim.sdk:maxim-java:1.1.0")
 ```
 2. Maven
 
@@ -28,7 +28,7 @@ implementation("dev.getmaxim.sdk:maxim-java:0.1.2")
 
 ## Version changelog
 
-## v1.1.0
+### v1.1.0
 
 - Adds support for ToolCalls, Attachments
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,12 +2,12 @@ import com.vanniktech.maven.publish.SonatypeHost
 import org.gradle.api.JavaVersion
 import org.gradle.external.javadoc.StandardJavadocDocletOptions
 
-tasks.test {
-    useJUnitPlatform()
-    environment("TEST_API_KEY", "test-key-123")
-    environment("TEST_DB_URL", "jdbc:h2:mem:test")
-    environment("ENV", "test")
-}
+//tasks.test {
+//    useJUnitPlatform()
+//    environment("TEST_API_KEY", "test-key-123")
+//    environment("TEST_DB_URL", "jdbc:h2:mem:test")
+//    environment("ENV", "test")
+//}
 
 plugins {
     kotlin("jvm") version "2.0.20"
@@ -47,7 +47,7 @@ mavenPublishing {
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, true)
     signAllPublications()
 
-    coordinates(group.toString(), "maxim-java", version.toString())
+    coordinates(group.toString(), "sdk", version.toString())
 
     pom {
         name.set("Maxim Java Library")


### PR DESCRIPTION
### TL;DR

Updated Maven coordinates and version references for the Maxim Java SDK.

### What changed?

- Updated the SDK version in README.md from `0.1.2` to `1.1.0`
- Fixed the heading format for version `1.1.0` in the changelog (changed from `##` to `###`)
- Changed Maven artifact ID from `maxim-java` to `sdk` in the build configuration
- Commented out the test configuration block in build.gradle.kts

### How to test?

1. Verify that the Maven coordinates work correctly by adding the dependency to a test project:
   ```groovy
   implementation("dev.getmaxim.sdk:sdk:1.1.0")
   ```
2. Ensure the README documentation accurately reflects the new artifact ID and version

### Why make this change?

This change standardizes the artifact naming convention to better align with the project structure and prepares for the v1.1.0 release. The artifact ID change from `maxim-java` to `sdk` provides a more consistent naming pattern for the library.